### PR TITLE
Remove UTF‑8 BOM from frontend

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -1,4 +1,4 @@
-﻿/* Zajištění responsivního designu */
+/* Zajištění responsivního designu */
 body {
     background-color: #000; /* Černé pozadí pro Fallout styl */
     color: #0f0; /* Zelený text pro Fallout styl */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -1,4 +1,4 @@
-﻿function selectRole(role) {
+function selectRole(role) {
   localStorage.setItem('selectedRole', role);
   if (role === 'Overseer') {
     window.location.href = 'overseer.html';

--- a/frontend/js/overseer.js
+++ b/frontend/js/overseer.js
@@ -1,4 +1,4 @@
-﻿function updateStat(player, stat, value) {
+function updateStat(player, stat, value) {
   const playerData = JSON.parse(localStorage.getItem(player)) || {};
   playerData[stat] = value;
   localStorage.setItem(player, JSON.stringify(playerData));

--- a/frontend/js/player.js
+++ b/frontend/js/player.js
@@ -1,4 +1,4 @@
-﻿const role = localStorage.getItem('selectedRole');
+const role = localStorage.getItem('selectedRole');
 document.getElementById('roleName').innerText = role;
 
 function useAbility() {

--- a/frontend/overseer.html
+++ b/frontend/overseer.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">

--- a/frontend/player.html
+++ b/frontend/player.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->

--- a/frontend/radio.html
+++ b/frontend/radio.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
## Summary
- strip BOM characters from HTML, CSS, and JS files in frontend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68443cb77d78832d979258548d862b85