### PR TITLE
Enable skipping intro via Home button

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -48,23 +48,5 @@
     </div>
 
     <script src="js/main.js"></script>
-    <script>
-        window.onload = function () {
-            localStorage.removeItem('selectedRole');
-        };
-
-        function selectRole(role) {
-            // Uloží ID postavy do localStorage
-            localStorage.setItem('selectedRole', role);
-
-            // Přesměruje na player.html
-            window.location.href = 'player.html';
-        }
-
-        if (!playerId) {
-            window.location.href = 'index.html';
-            return;
-        }
-    </script>
 </body>
 </html>

--- a/frontend/inv.html
+++ b/frontend/inv.html
@@ -36,7 +36,7 @@
                     <a class="nav-link" href="#">RADIO</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="index.html">HOME</a>
+                    <a class="nav-link" href="index.html?skipIntro=1">HOME</a>
                 </li>
             </ul>
         </div>

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -6,26 +6,41 @@ function selectRole(role) {
     window.location.href = 'player.html';
   }
 }
+
 // Po načtení stránky
 window.onload = function () {
-    const video = document.getElementById('intro');
+  // Při otevření domovské stránky vymažeme zvolenou roli
+  localStorage.removeItem('selectedRole');
 
-    // Zkontroluje, zda prohlížeč povolí přehrávání se zvukem
-    const playVideoWithSound = () => {
-        video.muted = false; // Zruší ztlumení
-        video.play(); // Spustí video
-    };
+  const params = new URLSearchParams(window.location.search);
+  const skipIntro = params.get('skipIntro');
 
-    // Pokud prohlížeč blokuje zvuk, čeká na interakci uživatele
-    if (video.muted || video.paused) {
-        document.body.addEventListener('click', playVideoWithSound, { once: true });
-    }
+  const videoContainer = document.getElementById('intro-video');
+  const video = document.getElementById('intro');
+  const selection = document.querySelector('.character-selection');
 
-    // Přechod na výběr postav po skončení videa
-    video.onended = function () {
-        document.getElementById('intro-video').style.display = 'none';
-        document.querySelector('.character-selection').style.display = 'block';
-    };
+  if (skipIntro) {
+    if (videoContainer) videoContainer.style.display = 'none';
+    if (selection) selection.style.display = 'block';
+    return; // přeskočíme přehrávání
+  }
+
+  // Zkontroluje, zda prohlížeč povolí přehrávání se zvukem
+  const playVideoWithSound = () => {
+    video.muted = false; // Zruší ztlumení
+    video.play(); // Spustí video
+  };
+
+  // Pokud prohlížeč blokuje zvuk, čeká na interakci uživatele
+  if (video.muted || video.paused) {
+    document.body.addEventListener('click', playVideoWithSound, { once: true });
+  }
+
+  // Přechod na výběr postav po skončení videa
+  video.onended = function () {
+    if (videoContainer) videoContainer.style.display = 'none';
+    if (selection) selection.style.display = 'block';
+  };
 };
 
 

--- a/frontend/js/navigation.js
+++ b/frontend/js/navigation.js
@@ -27,7 +27,7 @@ function generateNavigation() {
 
   // Definujeme navigační položky
   const navItems = [
-    { name: 'HOME', config: { page: 'index.html' } },
+    { name: 'HOME', config: { page: 'index.html?skipIntro=1' } },
     { name: 'STAT', config: pages.STAT },
     { name: 'INV', config: pages.INV },
     { name: 'DATA', config: pages.DATA },

--- a/frontend/player.html
+++ b/frontend/player.html
@@ -36,7 +36,7 @@
                     <a class="nav-link" href="radio.html"> RADIO</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="index.html">HOME</a>
+                    <a class="nav-link" href="index.html?skipIntro=1">HOME</a>
                 </li>
             </ul>
         </div>

--- a/frontend/radio.html
+++ b/frontend/radio.html
@@ -28,7 +28,7 @@
                     <a class="nav-link" aria-current="page" href="radio.html">RADIO</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="index.html">HOME</a>
+                    <a class="nav-link" href="index.html?skipIntro=1">HOME</a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
## Summary
- allow skipping intro video with `skipIntro` query parameter
- clean up duplicate inline script on `index.html`
- update Home links to use `skipIntro`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844499b5b48832d945249fb5bc75892