### PR TITLE
Fix overseer write failures in read-only env

### DIFF
--- a/backend/data/players.js
+++ b/backend/data/players.js
@@ -1,16 +1,21 @@
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, copyFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { tmpdir } from 'os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const dataPath = join(__dirname, 'players.json');
+const tmpPath = join(tmpdir(), 'players.json');
 
 export function loadPlayers() {
-  return JSON.parse(readFileSync(dataPath, 'utf8'));
+  if (!existsSync(tmpPath)) {
+    copyFileSync(dataPath, tmpPath);
+  }
+  return JSON.parse(readFileSync(tmpPath, 'utf8'));
 }
 
 export function savePlayers(players) {
-  writeFileSync(dataPath, JSON.stringify(players, null, 2));
+  writeFileSync(tmpPath, JSON.stringify(players, null, 2));
 }
 
 export default loadPlayers();


### PR DESCRIPTION
## Summary
- prevent crashes on PATCH `/api/overseer` by copying player data to a writable temp dir

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68445732d180832db5cab13dad63e316