### PR TITLE
Improve mobile UX with responsive nav and styles

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -655,3 +655,32 @@ p {
 .player-item button:hover {
     background-color: #0c0;
 }
+
+/* Additional mobile tweaks */
+@media (max-width: 600px) {
+    h1 {
+        font-size: 22px;
+    }
+
+    .character-selection {
+        gap: 10px;
+    }
+
+    .character img {
+        width: 100px;
+        height: 100px;
+    }
+
+    .navbar-light .navbar-nav > li.nav-item > .nav-link {
+        font-size: 24px;
+    }
+
+    .nav.nav-tabs .nav-item .nav-link {
+        font-size: 18px;
+        padding: 3px 10px;
+    }
+
+    .stat-footer {
+        font-size: 18px;
+    }
+}

--- a/frontend/inv.html
+++ b/frontend/inv.html
@@ -18,6 +18,9 @@
 
 <body>
     <nav class="navbar-light navbars navbar navbar-expand-lg">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav">
                 <li class="nav-item">

--- a/frontend/overseer.html
+++ b/frontend/overseer.html
@@ -13,6 +13,9 @@
 <body>
   <!-- Hlavní navigace (dynamicky generovaná) -->
   <nav class="navbar-light navbars navbar navbar-expand-lg">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav" id="dynamic-nav">
         <!-- Dynamicky generovaná navigace se vloží sem -->

--- a/frontend/player.html
+++ b/frontend/player.html
@@ -18,6 +18,9 @@
 
 <body>
     <nav class="navbar-light navbars navbar navbar-expand-lg">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav">
                 <li class="nav-item active">

--- a/frontend/radio.html
+++ b/frontend/radio.html
@@ -10,6 +10,9 @@
 </head>
 <body>
     <nav class="navbar-light navbars navbar navbar-expand-lg">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav">
                 <li class="nav-item">


### PR DESCRIPTION
## Summary
- add responsive navbar toggler buttons
- tweak styling for small screens to improve mobile UX

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684458459bb4832da115412558d37d04