### PR TITLE
Add README instructions for Vercel CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ npm test
 
 Deployment is done through Vercel.  Running `npx vercel` (and following the prompts) will upload the code and configure the rewrites defined in `vercel.json`.  Once deployed the static files and serverless functions will be served from the generated URL.
 
+## Continuous Deployment
+
+To automate deployments you can link this repository to Vercel. From the Vercel
+dashboard choose **Add New&hellip;** → **Project**, import the GitHub repository
+and complete the setup. Once connected, every merge to the main branch will
+trigger a new deployment automatically. With the GitHub integration enabled you
+no longer need to run `npx vercel` manually.
+


### PR DESCRIPTION
## Summary
- document how to link GitHub to Vercel for automatic deployments
- note that `npx vercel` is unnecessary once the integration is enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684460e2c570832d8ea5e1b7302fdccb