### PR TITLE
Add Overseer API tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "fallout_alabama",
   "type": "module",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test --test-concurrency=1"
   }
 }

--- a/tests/api-characters.test.js
+++ b/tests/api-characters.test.js
@@ -1,9 +1,18 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { existsSync, unlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import handler from '../api/characters.js';
 import characters from '../backend/data/players.js';
 
-test('GET /api/characters returns list', () => {
+const tmpPath = join(tmpdir(), 'players.json');
+
+test.beforeEach(() => {
+  if (existsSync(tmpPath)) unlinkSync(tmpPath);
+});
+
+test('GET /api/characters returns list', { concurrency: false }, () => {
   const req = { method: 'GET', query: {} };
   let statusCode;
   let data;
@@ -17,7 +26,7 @@ test('GET /api/characters returns list', () => {
   assert.deepEqual(data, characters);
 });
 
-test('GET /api/characters?id=nonexistent returns 404', () => {
+test('GET /api/characters?id=nonexistent returns 404', { concurrency: false }, () => {
   const req = { method: 'GET', query: { id: 'nonexistent' } };
   let statusCode;
   let data;
@@ -31,7 +40,7 @@ test('GET /api/characters?id=nonexistent returns 404', () => {
   assert.deepEqual(data, { error: 'Character not found' });
 });
 
-test('PATCH /api/characters updates stats', () => {
+test('PATCH /api/characters updates stats', { concurrency: false }, () => {
   const req = { method: 'PATCH', query: { id: 'Engineer' }, body: { strength: 7 } };
   let statusCode;
   let data;

--- a/tests/api-overseer.test.js
+++ b/tests/api-overseer.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, unlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import handler from '../api/overseer.js';
+
+const tmpPath = join(tmpdir(), 'players.json');
+
+test.beforeEach(() => {
+  if (existsSync(tmpPath)) unlinkSync(tmpPath);
+});
+
+test('PATCH /api/overseer updates hp', { concurrency: false }, () => {
+  const req = { method: 'PATCH', query: { id: 'Engineer' }, body: { hp: 55 } };
+  let statusCode;
+  let data;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(obj) { data = obj; return this; },
+    setHeader() {}
+  };
+  handler(req, res);
+  assert.strictEqual(statusCode, 200);
+  assert.strictEqual(data.hp, 55);
+});
+
+test('POST /api/overseer adds item', { concurrency: false }, () => {
+  const req = { method: 'POST', query: { id: 'Engineer' }, body: { item: 'Spear' } };
+  let statusCode;
+  let data;
+  const res = {
+    status(code) { statusCode = code; return this; },
+    json(obj) { data = obj; return this; },
+    setHeader() {}
+  };
+  handler(req, res);
+  assert.strictEqual(statusCode, 200);
+  assert.deepEqual(data.inventory, ['Spear']);
+});
+
+test('DELETE /api/overseer removes item', { concurrency: false }, () => {
+  // add item first
+  let statusCode;
+  let data;
+  let res = {
+    status(code) { statusCode = code; return this; },
+    json(obj) { data = obj; return this; },
+    setHeader() {}
+  };
+  handler({ method: 'POST', query: { id: 'Engineer' }, body: { item: 'Gun' } }, res);
+
+  // now delete
+  statusCode = undefined;
+  data = undefined;
+  res = {
+    status(code) { statusCode = code; return this; },
+    json(obj) { data = obj; return this; },
+    setHeader() {}
+  };
+  handler({ method: 'DELETE', query: { id: 'Engineer', itemId: '0' }, body: {} }, res);
+  assert.strictEqual(statusCode, 200);
+  assert.deepEqual(data.inventory, []);
+});


### PR DESCRIPTION
## Summary
- reset temporary players file before each test
- add new tests for overseer API covering PATCH/POST/DELETE
- run tests sequentially by default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684460e41d38832db22e04fb95f2ba88