### PR TITLE
Add PostgreSQL database layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,23 @@ therefore lost between invocations.
 For persistent player data consider connecting the API to an external data store
 such as a database or Vercel KV/Edge Config.
 
+## Database configuration
+
+The API will look for a `DATABASE_URL` environment variable pointing to a
+PostgreSQL database. When omitted, it falls back to the temporary JSON file used
+in the earlier version of this project. This makes local development work
+without any additional setup while allowing production deployments to persist
+data.
+
+### Quick start with Vercel Postgres
+
+```bash
+vercel postgres create fallout-db
+# once the database is created retrieve the connection string
+vercel env add DATABASE_URL
+```
+
+The value you enter for `DATABASE_URL` should match the connection string shown
+in the Vercel dashboard. After redeploying the project the API will store player
+information inside this database.
+

--- a/api/characters.js
+++ b/api/characters.js
@@ -1,23 +1,23 @@
-import { loadPlayers, savePlayers } from '../backend/data/players.js';
+import { getPlayers, getPlayerById, updatePlayer } from '../backend/data/db.js';
 
-export default function handler(req, res) {
+export default async function handler(req, res) {
     const { id } = req.query;
-    const characters = loadPlayers();
 
     if (req.method === 'GET') {
         if (id) {
-            const character = characters.find(c => c.id === id);
+            const character = await getPlayerById(id);
             if (!character) {
                 return res.status(404).json({ error: 'Character not found' });
             }
             return res.status(200).json(character);
         }
+        const characters = await getPlayers();
         return res.status(200).json(characters);
     }
 
     if (req.method === 'PATCH') {
-        const character = characters.find(c => c.id === id);
-        if (!character) {
+        const existing = await getPlayerById(id);
+        if (!existing) {
             return res.status(404).json({ error: 'Character not found' });
         }
 
@@ -34,20 +34,20 @@ export default function handler(req, res) {
             luck,
         } = req.body;
 
-        if (hp !== undefined) character.hp = hp;
-        if (ap !== undefined) character.ap = ap;
-        if (currency !== undefined) character.currency = currency;
-        if (strength !== undefined) character.strength = strength;
-        if (perception !== undefined) character.perception = perception;
-        if (endurance !== undefined) character.endurance = endurance;
-        if (charisma !== undefined) character.charisma = charisma;
-        if (intelligence !== undefined) character.intelligence = intelligence;
-        if (agility !== undefined) character.agility = agility;
-        if (luck !== undefined) character.luck = luck;
+        const updated = await updatePlayer(id, {
+            ...(hp !== undefined && { hp }),
+            ...(ap !== undefined && { ap }),
+            ...(currency !== undefined && { currency }),
+            ...(strength !== undefined && { strength }),
+            ...(perception !== undefined && { perception }),
+            ...(endurance !== undefined && { endurance }),
+            ...(charisma !== undefined && { charisma }),
+            ...(intelligence !== undefined && { intelligence }),
+            ...(agility !== undefined && { agility }),
+            ...(luck !== undefined && { luck }),
+        });
 
-        savePlayers(characters);
-
-        return res.status(200).json(character);
+        return res.status(200).json(updated);
     }
 
     res.setHeader('Allow', ['GET', 'PATCH']);

--- a/api/overseer.js
+++ b/api/overseer.js
@@ -1,13 +1,11 @@
-import { loadPlayers, savePlayers } from '../backend/data/players.js';
+import { getPlayerById, updatePlayer, addItem, removeItem } from '../backend/data/db.js';
 
-export default function handler(req, res) {
+export default async function handler(req, res) {
     const { id, itemId } = req.query;
-    const characters = loadPlayers();
 
     if (req.method === 'PATCH') {
-        const index = characters.findIndex(c => c.id === id);
-        if (index === -1) return res.status(404).json({ error: 'Character not found' });
-        const character = characters[index];
+        const character = await getPlayerById(id);
+        if (!character) return res.status(404).json({ error: 'Character not found' });
 
         const {
             hp,
@@ -56,44 +54,35 @@ export default function handler(req, res) {
             return res.status(400).json({ error: 'Luck must be between 1 and 10' });
         }
 
-        // Aktualizace atributů
-        if (hp !== undefined) character.hp = hp;
-        if (ap !== undefined) character.ap = ap;
-        if (currency !== undefined) character.currency = currency;
-        if (strength !== undefined) character.strength = strength;
-        if (perception !== undefined) character.perception = perception;
-        if (endurance !== undefined) character.endurance = endurance;
-        if (charisma !== undefined) character.charisma = charisma;
-        if (intelligence !== undefined) character.intelligence = intelligence;
-        if (agility !== undefined) character.agility = agility;
-        if (luck !== undefined) character.luck = luck;
+        const updated = await updatePlayer(id, {
+            ...(hp !== undefined && { hp }),
+            ...(ap !== undefined && { ap }),
+            ...(currency !== undefined && { currency }),
+            ...(strength !== undefined && { strength }),
+            ...(perception !== undefined && { perception }),
+            ...(endurance !== undefined && { endurance }),
+            ...(charisma !== undefined && { charisma }),
+            ...(intelligence !== undefined && { intelligence }),
+            ...(agility !== undefined && { agility }),
+            ...(luck !== undefined && { luck }),
+        });
 
-        savePlayers(characters);
-
-        return res.status(200).json(character);
+        return res.status(200).json(updated);
     }
 
     if (req.method === 'POST') {
-        const character = characters.find(c => c.id === id);
-        if (!character) return res.status(404).json({ error: 'Character not found' });
-
         const { item } = req.body;
         if (!item) return res.status(400).json({ error: 'Item is required' });
 
-        // Přidání předmětu do inventáře
-        character.inventory.push(item);
-        savePlayers(characters);
-        return res.status(200).json(character);
+        const updated = await addItem(id, item);
+        if (!updated) return res.status(404).json({ error: 'Character not found' });
+        return res.status(200).json(updated);
     }
 
     if (req.method === 'DELETE') {
-        const character = characters.find(c => c.id === id);
-        if (!character) return res.status(404).json({ error: 'Character not found' });
-
-        // Odebrání předmětu z inventáře
-        character.inventory = character.inventory.filter((_, index) => index != itemId);
-        savePlayers(characters);
-        return res.status(200).json(character);
+        const updated = await removeItem(id, itemId);
+        if (!updated) return res.status(404).json({ error: 'Character not found' });
+        return res.status(200).json(updated);
     }
 
     res.setHeader('Allow', ['PATCH', 'POST', 'DELETE']);

--- a/backend/data/db.js
+++ b/backend/data/db.js
@@ -1,0 +1,92 @@
+import pg from 'pg';
+import { loadPlayers, savePlayers } from './players.js';
+
+const { Pool } = pg;
+let pool;
+
+function getPool() {
+  if (!pool) {
+    if (!process.env.DATABASE_URL) {
+      throw new Error('DATABASE_URL is not defined');
+    }
+    pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  }
+  return pool;
+}
+
+const useFile = !process.env.DATABASE_URL || process.env.TEST_DB === 'file';
+
+export async function getPlayers() {
+  if (useFile) {
+    return loadPlayers();
+  }
+  const { rows } = await getPool().query('SELECT * FROM players ORDER BY id');
+  return rows;
+}
+
+export async function getPlayerById(id) {
+  if (useFile) {
+    return loadPlayers().find(p => p.id === id);
+  }
+  const { rows } = await getPool().query('SELECT * FROM players WHERE id=$1', [id]);
+  return rows[0];
+}
+
+export async function updatePlayer(id, fields) {
+  if (useFile) {
+    const players = loadPlayers();
+    const index = players.findIndex(p => p.id === id);
+    if (index === -1) return null;
+    Object.assign(players[index], fields);
+    savePlayers(players);
+    return players[index];
+  }
+  const keys = Object.keys(fields);
+  if (keys.length === 0) {
+    return getPlayerById(id);
+  }
+  const set = keys.map((k, i) => `"${k}"=$${i + 2}`).join(', ');
+  const values = Object.values(fields);
+  const { rows } = await getPool().query(
+    `UPDATE players SET ${set} WHERE id=$1 RETURNING *`,
+    [id, ...values]
+  );
+  return rows[0];
+}
+
+export async function addItem(id, item) {
+  if (useFile) {
+    const players = loadPlayers();
+    const player = players.find(p => p.id === id);
+    if (!player) return null;
+    player.inventory.push(item);
+    savePlayers(players);
+    return player;
+  }
+  const { rows } = await getPool().query(
+    'UPDATE players SET inventory = array_append(inventory, $2) WHERE id=$1 RETURNING *',
+    [id, item]
+  );
+  return rows[0];
+}
+
+export async function removeItem(id, itemId) {
+  if (useFile) {
+    const players = loadPlayers();
+    const player = players.find(p => p.id === id);
+    if (!player) return null;
+    player.inventory = player.inventory.filter((_, idx) => idx != itemId);
+    savePlayers(players);
+    return player;
+  }
+  const { rows } = await getPool().query(
+    `UPDATE players SET inventory = (
+      SELECT array_agg(elem) FROM (
+        SELECT elem FROM unnest(inventory) WITH ORDINALITY t(elem, idx)
+        WHERE idx <> $2 + 1
+      ) s
+    ) WHERE id=$1 RETURNING *`,
+    [id, Number(itemId)]
+  );
+  return rows[0];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,159 @@
+{
+  "name": "fallout_alabama",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fallout_alabama",
+      "dependencies": {
+        "pg": "^8.11.3"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.0.tgz",
+      "integrity": "sha512-7SKfdvP8CTNXjMUzfcVTaI+TDzBEeaUnVwiVGZQD1Hh33Kpev7liQba9uLd4CfN8r9mCVsD0JIpq03+Unpz+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.0",
+        "pg-pool": "^3.10.0",
+        "pg-protocol": "^1.10.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.5"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.5.tgz",
+      "integrity": "sha512-OOX22Vt0vOSRrdoUPKJ8Wi2OpE/o/h9T8X1s4qSkCedbNah9ei2W2765be8iMVxQUsvgT7zIAT2eIa9fs5+vtg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.0.tgz",
+      "integrity": "sha512-P2DEBKuvh5RClafLngkAuGe9OUlFV7ebu8w1kmaaOgPcpJd1RIFh7otETfI6hAR8YupOLFTY7nuvvIn7PLciUQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.0.tgz",
+      "integrity": "sha512-DzZ26On4sQ0KmqnO34muPcmKbhrjmyiO4lCCR0VwEd7MjmiKf5NTg/6+apUEu0NF7ESa37CGzFxH513CoUmWnA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.0.tgz",
+      "integrity": "sha512-IpdytjudNuLv8nhlHs/UrVBhU0e78J0oIS/0AVdTbWxSOkFUVdsHC/NrorO6nXsQNDTT1kzDSOMJubBQviX18Q==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
   "type": "module",
   "scripts": {
     "test": "node --test --test-concurrency=1"
+  },
+  "dependencies": {
+    "pg": "^8.11.3"
   }
 }

--- a/tests/api-characters.test.js
+++ b/tests/api-characters.test.js
@@ -3,8 +3,9 @@ import assert from 'node:assert/strict';
 import { existsSync, unlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+process.env.TEST_DB = 'file';
 import handler from '../api/characters.js';
-import characters from '../backend/data/players.js';
+import { loadPlayers } from '../backend/data/players.js';
 
 const tmpPath = join(tmpdir(), 'players.json');
 
@@ -12,7 +13,7 @@ test.beforeEach(() => {
   if (existsSync(tmpPath)) unlinkSync(tmpPath);
 });
 
-test('GET /api/characters returns list', { concurrency: false }, () => {
+test('GET /api/characters returns list', { concurrency: false }, async () => {
   const req = { method: 'GET', query: {} };
   let statusCode;
   let data;
@@ -21,12 +22,12 @@ test('GET /api/characters returns list', { concurrency: false }, () => {
     json(obj) { data = obj; return this; },
     setHeader() {}
   };
-  handler(req, res);
+  await handler(req, res);
   assert.strictEqual(statusCode, 200);
-  assert.deepEqual(data, characters);
+  assert.deepEqual(data, loadPlayers());
 });
 
-test('GET /api/characters?id=nonexistent returns 404', { concurrency: false }, () => {
+test('GET /api/characters?id=nonexistent returns 404', { concurrency: false }, async () => {
   const req = { method: 'GET', query: { id: 'nonexistent' } };
   let statusCode;
   let data;
@@ -35,12 +36,12 @@ test('GET /api/characters?id=nonexistent returns 404', { concurrency: false }, (
     json(obj) { data = obj; return this; },
     setHeader() {}
   };
-  handler(req, res);
+  await handler(req, res);
   assert.strictEqual(statusCode, 404);
   assert.deepEqual(data, { error: 'Character not found' });
 });
 
-test('PATCH /api/characters updates stats', { concurrency: false }, () => {
+test('PATCH /api/characters updates stats', { concurrency: false }, async () => {
   const req = { method: 'PATCH', query: { id: 'Engineer' }, body: { strength: 7 } };
   let statusCode;
   let data;
@@ -49,7 +50,7 @@ test('PATCH /api/characters updates stats', { concurrency: false }, () => {
     json(obj) { data = obj; return this; },
     setHeader() {}
   };
-  handler(req, res);
+  await handler(req, res);
   assert.strictEqual(statusCode, 200);
   assert.strictEqual(data.strength, 7);
 });

--- a/tests/api-overseer.test.js
+++ b/tests/api-overseer.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { existsSync, unlinkSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+process.env.TEST_DB = 'file';
 import handler from '../api/overseer.js';
 
 const tmpPath = join(tmpdir(), 'players.json');
@@ -11,7 +12,7 @@ test.beforeEach(() => {
   if (existsSync(tmpPath)) unlinkSync(tmpPath);
 });
 
-test('PATCH /api/overseer updates hp', { concurrency: false }, () => {
+test('PATCH /api/overseer updates hp', { concurrency: false }, async () => {
   const req = { method: 'PATCH', query: { id: 'Engineer' }, body: { hp: 55 } };
   let statusCode;
   let data;
@@ -20,12 +21,12 @@ test('PATCH /api/overseer updates hp', { concurrency: false }, () => {
     json(obj) { data = obj; return this; },
     setHeader() {}
   };
-  handler(req, res);
+  await handler(req, res);
   assert.strictEqual(statusCode, 200);
   assert.strictEqual(data.hp, 55);
 });
 
-test('POST /api/overseer adds item', { concurrency: false }, () => {
+test('POST /api/overseer adds item', { concurrency: false }, async () => {
   const req = { method: 'POST', query: { id: 'Engineer' }, body: { item: 'Spear' } };
   let statusCode;
   let data;
@@ -34,12 +35,12 @@ test('POST /api/overseer adds item', { concurrency: false }, () => {
     json(obj) { data = obj; return this; },
     setHeader() {}
   };
-  handler(req, res);
+  await handler(req, res);
   assert.strictEqual(statusCode, 200);
   assert.deepEqual(data.inventory, ['Spear']);
 });
 
-test('DELETE /api/overseer removes item', { concurrency: false }, () => {
+test('DELETE /api/overseer removes item', { concurrency: false }, async () => {
   // add item first
   let statusCode;
   let data;
@@ -48,7 +49,7 @@ test('DELETE /api/overseer removes item', { concurrency: false }, () => {
     json(obj) { data = obj; return this; },
     setHeader() {}
   };
-  handler({ method: 'POST', query: { id: 'Engineer' }, body: { item: 'Gun' } }, res);
+  await handler({ method: 'POST', query: { id: 'Engineer' }, body: { item: 'Gun' } }, res);
 
   // now delete
   statusCode = undefined;
@@ -58,7 +59,7 @@ test('DELETE /api/overseer removes item', { concurrency: false }, () => {
     json(obj) { data = obj; return this; },
     setHeader() {}
   };
-  handler({ method: 'DELETE', query: { id: 'Engineer', itemId: '0' }, body: {} }, res);
+  await handler({ method: 'DELETE', query: { id: 'Engineer', itemId: '0' }, body: {} }, res);
   assert.strictEqual(statusCode, 200);
   assert.deepEqual(data.inventory, []);
 });


### PR DESCRIPTION
## Summary
- install `pg` and add lockfile
- create `backend/data/db.js` as a wrapper around `pg` or local JSON
- refactor API routes to use the new DB helpers
- document `DATABASE_URL` env var and Vercel Postgres setup
- update tests to use the DB helpers in file mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684464520548832da14a40073de5644a