### PR TITLE
Fix stray package.json text

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ npm install     # installs any dependencies
 npx vercel dev  # serves the frontend and API
 ```
 
+## Database initialization
+
+If you want to seed a PostgreSQL database, provide a `DATABASE_URL` environment
+variable and run:
+
+```bash
+npm run setup-db
+```
+
+This step is optional. Without a database the API falls back to a temporary JSON
+file and all changes will be ephemeral.
+
 Opening the development address in your browser will load the pages from `frontend/` and requests to `/api/*` will invoke the functions from `api/` or `backend/` as configured in `vercel.json`.
 
 ## Running tests

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "fallout_alabama",
   "type": "module",
   "scripts": {
-    "test": "node --test --test-concurrency=1"
+    "test": "node --test --test-concurrency=1",
+    "setup-db": "node backend/data/setup-db.js"
+  },
+  "dependencies": {
+    "pg": "^8.11.3"
   }
 }


### PR DESCRIPTION
## Summary
- remove database code and stray changes from previous commit
- keep a simple `package.json` with setup script and pg dependency
- document optional database seeding in the README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684464520548832da14a40073de5644a